### PR TITLE
Fixed vue cdn script based on environment

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,5 +1,9 @@
 {% include ga.html %}
-<script src="//unpkg.com/vue"></script>
+{% if jekyll.environment == "production" %}
+<script src="https://cdn.jsdelivr.net/npm/vue"></script>
+{% else %}
+<script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
+{% endif %}
 <script src="//unpkg.com/axios/dist/axios.min.js"></script>
 <script src="{{ 'portfolio.min.js' | prepend: site.assets.js }}"></script>
 <script src="{{ 'portfolio.1.min.js' | prepend: site.assets.js }}"></script>


### PR DESCRIPTION
### Issue
The `vue` CDN isn't loading the correctly script on production mode.

### Solution
Added condition based on environment for load the correctly script.

--
Ref. #1 