### PR TITLE
Fixed html lang and doctype

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,4 +1,5 @@
-<html language="{{ page.language }}">
+<!DOCTYPE html>
+<html lang="{{ page.language }}">
     {% include head.html %}
     <body>
         {% include header.html %}


### PR DESCRIPTION
### Issue
- **[Accessibility]** <html> element does not have a [lang] attribute.
- **[Best Practices]** Document mus contain a `doctype`.

### Solution
- Changed `<html>`attribute from `language` to `lang`.
- Added missing `doctype` in document.


--
Ref. #1 